### PR TITLE
Add pack_i16() and unpack_u8() helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ This prevents:
 ```cpp
 pack_u8(data, index, value);
 pack_u16(data, index, value);
+pack_i16(data, index, value);
 pack_u32(data, index, value);
 pack_float(data, index, value);
 ```
@@ -242,6 +243,7 @@ pack_float(data, index, value);
 ### Unpacking Helpers (Big Endian)
 
 ```cpp
+unpack_u8(data, offset);
 unpack_u16(data, offset);
 unpack_i16(data, offset);
 unpack_u32(data, offset);

--- a/main/MSM_CAN.hpp
+++ b/main/MSM_CAN.hpp
@@ -63,6 +63,11 @@ namespace MSM_CAN
         data[index] = value;
     }
 
+    inline void pack_i16(uint8_t data[8], uint8_t index, int16_t value)                //helper function to pack uint8_t data[8] with a big-endian encoded int16_t
+    {
+        pack_u16(data, index, static_cast<uint16_t>(value));
+    }
+
     inline void pack_float(uint8_t data[8], uint8_t index, float value)                  // helper function to pack uint8_t data[8] with a big-endian encoded float
     {
         uint32_t bits = 0;
@@ -82,6 +87,13 @@ namespace MSM_CAN
     inline int16_t unpack_i16(const uint8_t data[8], uint8_t index)                 // helper function to unpack uint8_t data[8] with a big-endian encoded int16_t
     {
         return static_cast<int16_t>(unpack_u16(data, index));
+    }
+
+    inline uint8_t unpack_u8(const uint8_t data[8], uint8_t index)                  // helper function to unpack a single byte from uint8_t data[8]
+    {
+        if (data == nullptr || index > 7) return 0;
+
+        return data[index];
     }
 
     inline uint32_t unpack_u32(const uint8_t data[8], uint8_t index)                // helper function to unpack uint8_t data[8] with a big-endian encoded uint32_t


### PR DESCRIPTION
Adds two helper functions for CAN message packing/unpacking:
- pack_i16(): packs a signed 16-bit integer into two bytes
- unpack_u8(): unpacks a single unsigned byte

---
Submitted by [rawcell](https://github.com/quanticsoul4772/agent-harness-v2) (autonomous agent)